### PR TITLE
[FEAT] 사용자 정보 전역관리

### DIFF
--- a/src/component/common/Header.jsx
+++ b/src/component/common/Header.jsx
@@ -1,7 +1,10 @@
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { getCurrentUserInfo } from '../../lib/api/auth';
+import { getUserInfo } from '../../store/userInfo';
 
 const HeaderStyle = styled.div`
   display: flex;
@@ -44,29 +47,57 @@ const LogoutBtn = styled.button`
   cursor: pointer;
 `;
 
-const Header = ({ admin }) => (
-  <HeaderStyle>
-    <LogoBox to="/home">
-      <img src="/images/logo/logo.png" alt="logo" />
-    </LogoBox>
-    {admin ? (
-      <LogoutBtn>로그아웃</LogoutBtn>
-    ) : (
-      <IconBox>
-        <IconItem>
-          <Link to="/search">
-            <img src="/images/icons/search.png" alt="search" />
-          </Link>
-        </IconItem>
-        <IconItem>
-          <Link to="/home">
-            <img src="/images/icons/bell.png" alt="search" />
-          </Link>
-        </IconItem>
-      </IconBox>
-    )}
-  </HeaderStyle>
-);
+const Header = ({ admin }) => {
+  const info = useSelector(({ userInfo }) => (userInfo.info));
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const loadUser = () => {
+      try {
+        const user = localStorage.getItem('ACCESS_TOKEN');
+        if (!user) return; // 사용자가 로그인이 안된 경우
+
+        const loadAPI = async () => {
+          const response = await getCurrentUserInfo();
+
+          // 사용자가 ROLE_USER인 경우
+          if (response.status === 200) {
+            dispatch(getUserInfo(response.data.data));
+          }
+        };
+
+        if (!info) loadAPI();
+      } catch (e) {
+        console.log('localstorage is not working!');
+      }
+    };
+    loadUser();
+  }, []);
+
+  return (
+    <HeaderStyle>
+      <LogoBox to="/home">
+        <img src="/images/logo/logo.png" alt="logo" />
+      </LogoBox>
+      {admin ? (
+        <LogoutBtn>로그아웃</LogoutBtn>
+      ) : (
+        <IconBox>
+          <IconItem>
+            <Link to="/search">
+              <img src="/images/icons/search.png" alt="search" />
+            </Link>
+          </IconItem>
+          <IconItem>
+            <Link to="/home">
+              <img src="/images/icons/bell.png" alt="search" />
+            </Link>
+          </IconItem>
+        </IconBox>
+      )}
+    </HeaderStyle>
+  );
+};
 
 Header.propTypes = {
   admin: PropTypes.string,

--- a/src/constants/index.jsx
+++ b/src/constants/index.jsx
@@ -1,5 +1,5 @@
-export const API_BASE_URL = 'http://10.21.20.87:8080';
-export const REDIRECT_URL = 'http://localhost:3000/oauth2/redirect';
+export const API_BASE_URL = 'http://10.21.20.33:8080';
+export const REDIRECT_URL = 'http://10.21.20.15:3000/oauth2/redirect';
 
 export const KAKAO_AUTH_URL = `${API_BASE_URL}/oauth2/authorize/kakao?redirect_uri=${REDIRECT_URL}`;
 export const NAVER_AUTH_URL = `${API_BASE_URL}/oauth2/authorize/naver?redirect_uri=${REDIRECT_URL}`;

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,31 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import { Provider } from 'react-redux';
 import App from './App';
 import rootReducer from './store';
+import { getUserInfo } from './store/userInfo';
+import { getCurrentUserInfo } from './lib/api/auth';
 
 const store = createStore(rootReducer, composeWithDevTools());
+
+function loadUser() {
+  try {
+    const user = localStorage.getItem('ACCESS_TOKEN');
+
+    if (!user) return; // 사용자가 로그인이 안된 경우
+
+    const loadAPI = async () => {
+      const response = await getCurrentUserInfo();
+
+      // 사용자가 ROLE_USER인 경우
+      if (response.status === 200) {
+        store.dispatch(getUserInfo(response.data.data));
+      }
+    };
+    loadAPI();
+  } catch (e) {
+    console.log('localstorage is not working!');
+  }
+}
+loadUser();
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import './index.css';
 import { BrowserRouter } from 'react-router-dom';
 import { createStore } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
-import { Provider } from 'react-redux';
+import { Provider, useSelector } from 'react-redux';
 import App from './App';
 import rootReducer from './store';
 import { getUserInfo } from './store/userInfo';
@@ -15,7 +15,6 @@ const store = createStore(rootReducer, composeWithDevTools());
 function loadUser() {
   try {
     const user = localStorage.getItem('ACCESS_TOKEN');
-
     if (!user) return; // 사용자가 로그인이 안된 경우
 
     const loadAPI = async () => {

--- a/src/lib/api/auth.jsx
+++ b/src/lib/api/auth.jsx
@@ -24,3 +24,14 @@ export const imageUploader = async (imageList) => {
   });
   return response.data;
 };
+
+export const getCurrentUserInfo = async () => {
+  const response = await axios({
+    url: `${API_BASE_URL}/users`,
+    method: 'get',
+    headers: {
+      Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+    },
+  });
+  return response;
+};

--- a/src/store/index.jsx
+++ b/src/store/index.jsx
@@ -1,8 +1,9 @@
 import { combineReducers } from 'redux';
+import userInfo from './userInfo';
 
 // 여러 리듀서들을 취합하는 코드
 const rootReducer = combineReducers({
-
+  userInfo,
 });
 
 export default rootReducer;

--- a/src/store/userInfo.jsx
+++ b/src/store/userInfo.jsx
@@ -4,9 +4,7 @@ const GET_USER_INFO = 'userInfo/GET_USER_INFO';
 
 export const getUserInfo = createAction(GET_USER_INFO);
 
-const initialState = {
-  info: null,
-};
+const initialState = {};
 
 const userInfo = handleActions({
   [GET_USER_INFO]: (state, { payload: info }) => ({

--- a/src/store/userInfo.jsx
+++ b/src/store/userInfo.jsx
@@ -1,0 +1,18 @@
+import { createAction, handleActions } from 'redux-actions';
+
+const GET_USER_INFO = 'userInfo/GET_USER_INFO';
+
+export const getUserInfo = createAction(GET_USER_INFO);
+
+const initialState = {
+  info: null,
+};
+
+const userInfo = handleActions({
+  [GET_USER_INFO]: (state, { payload: info }) => ({
+    ...state,
+    info,
+  }),
+}, initialState);
+
+export default userInfo;


### PR DESCRIPTION
1. 모든 페이지에서 전역에 userInfo값이 있는지 체크한다.-> 있을 경우 userInfo API 호출, 없으면 호출하지 않는다.(Header.jsx)
2. 페이지 새로고침시, index.js에서 userInfo API를 호출하도록 세팅한다. -> 1번처럼 useEffect를 이용해서 호출하게 된다면, 한번 렌더링이 된 이후에 실행되기 때문에 깜박임현상이 발생할 수 있어, index.js에서 바로 처리해서 해결하였다.
