### PR TITLE
[FIX] getCommentParentId set 객체로 수정

### DIFF
--- a/src/component/Cocomment.jsx
+++ b/src/component/Cocomment.jsx
@@ -188,7 +188,7 @@ Cocomment.propTypes = {
     replyCount: PropTypes.number,
     userLike: PropTypes.bool,
   }).isRequired,
-  boardId: PropTypes.number.isRequired,
+  boardId: PropTypes.string.isRequired,
   userId: PropTypes.number.isRequired,
   onClickLoad: PropTypes.func,
   getEditComment: PropTypes.func,

--- a/src/component/Post.jsx
+++ b/src/component/Post.jsx
@@ -314,6 +314,7 @@ const Post = ({ boardId }) => {
                         onClickLoad={onClickLoad}
                         getEditComment={getEditComment}
                         getCommentParentId={getCommentParentId}
+                        key={comment.id}
                       />
                     ) : (
                       <Cocomment
@@ -322,6 +323,7 @@ const Post = ({ boardId }) => {
                         userId={info.id}
                         onClickLoad={onClickLoad}
                         getEditComment={getEditComment}
+                        key={comment.id}
                       />
                     ),
                   )}

--- a/src/component/Post.jsx
+++ b/src/component/Post.jsx
@@ -204,7 +204,7 @@ const Post = ({ boardId }) => {
 
   // 대댓글 작성시 parentId를 받아온다
   const getCommentParentId = parentId => {
-    setCommentParentId(parentId);
+    setCommentParentId({ parentId });
   };
 
   const load = async () => {

--- a/src/component/common/CommentInput.jsx
+++ b/src/component/common/CommentInput.jsx
@@ -59,7 +59,7 @@ const CommentInput = ({
       content: comment,
     };
     if (parentId) {
-      dto = { ...dto, parentId };
+      dto = { ...dto, ...parentId };
     }
     try {
       isEditComment

--- a/src/component/common/CommentInput.jsx
+++ b/src/component/common/CommentInput.jsx
@@ -110,7 +110,7 @@ CommentInput.propTypes = {
   boardId: PropTypes.string.isRequired,
   onClickLoad: PropTypes.func.isRequired,
   editCommentValue: PropTypes.objectOf(PropTypes.object),
-  commentParentId: PropTypes.number,
+  commentParentId: PropTypes.objectOf(PropTypes.number),
 };
 
 export default CommentInput;

--- a/src/component/common/HeaderWrapper.jsx
+++ b/src/component/common/HeaderWrapper.jsx
@@ -6,5 +6,5 @@ const HeaderWrapper = ({ children }) => <div>{children}</div>;
 export default HeaderWrapper;
 
 HeaderWrapper.propTypes = {
-  children: PropTypes.element,
+  children: PropTypes.arrayOf(PropTypes.element),
 };


### PR DESCRIPTION
useState를 숫자로 같은 값이 받아오면 변경 인식을 못해서 객체로 하였다.
결과로 대댓글 입력후 또 바로 같은 댓글의 대댓글을 다니 제대로 밑으로 대댓글이 달렸다.
#6